### PR TITLE
Change the Module creation interface.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 
 [dependencies]
 gimli = "0.27.0"
+object = { version = "0.30", optional = true }
 thiserror = "1.0.30"
 macho-unwind-info = "0.3.0"
 fallible-iterator = "0.2.0"

--- a/tests/integration_tests/macos.rs
+++ b/tests/integration_tests/macos.rs
@@ -76,7 +76,60 @@ fn test_basic() {
 #[test]
 fn test_root_doc_comment() {
     use framehop::aarch64::{CacheAarch64, UnwindRegsAarch64, UnwinderAarch64};
-    use framehop::{FrameAddress, Module, ModuleSvmaInfo, ModuleUnwindData, TextByteData};
+    use framehop::{FrameAddress, Module, ModuleSectionInfo};
+
+    struct ModuleSvmaInfo {
+        base_svma: u64,
+        text: std::ops::Range<u64>,
+        stubs: std::ops::Range<u64>,
+        stub_helper: std::ops::Range<u64>,
+        eh_frame: std::ops::Range<u64>,
+        got: std::ops::Range<u64>,
+        text_segment: std::ops::Range<u64>,
+    }
+
+    impl ModuleSectionInfo<Vec<u8>> for ModuleSvmaInfo {
+        fn base_svma(&self) -> u64 {
+            self.base_svma
+        }
+
+        fn section_svma_range(&self, name: &[u8]) -> Option<std::ops::Range<u64>> {
+            match name {
+                b"__text" => Some(self.text.clone()),
+                b"__stubs" => Some(self.stubs.clone()),
+                b"__stub_helper" => Some(self.stub_helper.clone()),
+                b"__eh_frame" => Some(self.eh_frame.clone()),
+                b"__got" => Some(self.got.clone()),
+                _ => None,
+            }
+        }
+
+        fn section_file_range(&self, _name: &[u8]) -> Option<std::ops::Range<u64>> {
+            None
+        }
+
+        fn section_data(&self, name: &[u8]) -> Option<Vec<u8>> {
+            match name {
+                b"__text" => Some(vec![]),
+                _ => None,
+            }
+        }
+
+        fn segment_file_range(&self, name: &[u8]) -> Option<std::ops::Range<u64>> {
+            match name {
+                b"__TEXT" => Some(self.text_segment.clone()),
+                _ => None,
+            }
+        }
+
+        fn segment_data(&self, name: &[u8]) -> Option<Vec<u8>> {
+            match name {
+                b"__TEXT" => Some(vec![]),
+                _ => None,
+            }
+        }
+    }
+
     let mut cache = CacheAarch64::<_>::new();
     let mut unwinder = UnwinderAarch64::new();
     let module = Module::new(
@@ -85,19 +138,13 @@ fn test_root_doc_comment() {
         0x1003fc000,
         ModuleSvmaInfo {
             base_svma: 0x100000000,
-            text: Some(0x100000b64..0x1001d2d18),
-            text_env: None,
-            stubs: Some(0x1001d2d18..0x1001d309c),
-            stub_helper: Some(0x1001d309c..0x1001d3438),
-            eh_frame: Some(0x100237f80..0x100237ffc),
-            eh_frame_hdr: None,
-            got: Some(0x100238000..0x100238010),
+            text: 0x100000b64..0x1001d2d18,
+            stubs: 0x1001d2d18..0x1001d309c,
+            stub_helper: 0x1001d309c..0x1001d3438,
+            eh_frame: 0x100237f80..0x100237ffc,
+            got: 0x100238000..0x100238010,
+            text_segment: 0x1003fc000..0x100634000,
         },
-        ModuleUnwindData::CompactUnwindInfoAndEhFrame(vec![/* __unwind_info */], None),
-        Some(TextByteData::new(
-            vec![/* __TEXT */],
-            0x1003fc000..0x100634000,
-        )),
     );
     unwinder.add_module(module);
 


### PR DESCRIPTION
There is now a more general `ModuleSectionInfo` trait which is used to query sections/segments as needed. This moves a lot of cumbersome conditional code into the library to make clients' lives easier.

This also adds `object` as an optional dependency, where (if enabled) the trait is implemented for references to `object::read::Object` types.