### PR TITLE
Add basic is_first_frame support for PE.

### DIFF
--- a/src/aarch64/pe.rs
+++ b/src/aarch64/pe.rs
@@ -7,6 +7,7 @@ impl PeUnwinding for ArchAarch64 {
         _sections: PeSections<D>,
         _address: u32,
         _regs: &mut Self::UnwindRegs,
+        _is_first_frame: bool,
         _read_stack: &mut F,
     ) -> Result<UnwindResult<Self::UnwindRule>, PeUnwinderError>
     where

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -71,6 +71,7 @@ pub trait PeUnwinding: Arch {
         sections: PeSections<D>,
         address: u32,
         regs: &mut Self::UnwindRegs,
+        is_first_frame: bool,
         read_stack: &mut F,
     ) -> Result<UnwindResult<Self::UnwindRule>, PeUnwinderError>
     where

--- a/src/unwinder.rs
+++ b/src/unwinder.rs
@@ -538,6 +538,7 @@ impl<
                 },
                 rel_lookup_address,
                 regs,
+                is_first_frame,
                 read_stack,
             )?,
             ModuleUnwindDataInternal::None => return Err(UnwinderError::NoModuleUnwindData),


### PR DESCRIPTION
Previously, the PE backend always attempted to perform instruction analysis. This was not only inefficient but also wrong. `address` was subtracted by one for return addresses found on the stack, which makes the lookup point to the previous instruction, but also meant that instruction decoding shouldn't happen, as it will likely be reading from the middle of an instruction.

Implement basic is_first_frame support, similar to what we are doing for DWARF. Later, we should extend this so that PUSH_MACHFRAME and .cfi_signal_frame would also be considered a "first frame".