### PR TITLE
Save the number of popped registers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ arrayvec = "0.7.4"
 [dev-dependencies]
 object = "0.32"
 flate2 = "1.0.28"
+itertools = "0.12.1"
 
 [profile.release]
 debug = true

--- a/src/rule_cache.rs
+++ b/src/rule_cache.rs
@@ -122,3 +122,23 @@ impl CacheStats {
         self.miss_empty_slot_count + self.miss_wrong_modules_count + self.miss_wrong_address_count
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{aarch64::UnwindRuleAarch64, x86_64::UnwindRuleX86_64};
+
+    use super::*;
+
+    // Ensure that the size of Option<CacheEntry<UnwindRuleX86_64>> doesn't change by accident.
+    #[test]
+    fn test_cache_entry_size() {
+        assert_eq!(
+            std::mem::size_of::<Option<CacheEntry<UnwindRuleX86_64>>>(),
+            16
+        );
+        assert_eq!(
+            std::mem::size_of::<Option<CacheEntry<UnwindRuleAarch64>>>(),
+            24 // <-- larger than we'd like
+        );
+    }
+}


### PR DESCRIPTION
This makes the encoding unambiguous. Fixes #25.

I'm removing the separate UnwindRuleOffsetSpAndPopRegisters type in order to store the fields more compactly inside UnwindRuleX86_64.