### PR TITLE
Added `no_std` option and split `pe` and `macho` into features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build
       run: cargo build --verbose
@@ -22,5 +22,18 @@ jobs:
       run: cargo test --verbose
     - name: Check formatting
       run: cargo fmt -- --check --verbose
+    # clippy all features, we use `hack` below to confirm each feature works
     - name: Clippy
-      run: cargo clippy --verbose -- -Dwarnings
+      run: cargo clippy --verbose --all-features -- -Dwarnings
+
+  hack:
+    # cargo-hack checks combinations of feature flags to ensure that features are all additive
+    # which is required for feature unification
+    runs-on: ubuntu-latest
+    name: check features
+    steps:
+      - uses: actions/checkout@v4
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: cargo hack
+        run: cargo hack --feature-powerset check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ gimli = { version = "0.28.1", default-features = false, features = ["read", "end
 object = { version = "0.32", optional = true }
 thiserror-no-std = "2.0.2"
 thiserror = { version = "1.0.0", optional = true }
-macho-unwind-info = "0.4.0"
-pe-unwind-info = "0.2.1"
+macho-unwind-info = { version = "0.4.0", optional = true }
+pe-unwind-info = { version = "0.2.1", optional = true }
 fallible-iterator = "0.3.0"
 arrayvec = { version = "0.7.4", default-features = false }
+cfg-if = "1.0.0"
 
 [features]
-default = ["std"]
+default = ["std", "macho", "pe"]
+macho = ["macho-unwind-info"]
+pe = ["pe-unwind-info"]
 std = ["arrayvec/std", "thiserror", "gimli/std"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,18 @@ repository = "https://github.com/mstange/framehop/"
 exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 
 [dependencies]
-gimli = "0.28.1"
+gimli = { version = "0.28.1", default-features = false, features = ["read", "endian-reader"] }
 object = { version = "0.32", optional = true }
-thiserror = "1.0.56"
+thiserror-no-std = "2.0.2"
+thiserror = { version = "1.0.0", optional = true }
 macho-unwind-info = "0.4.0"
 pe-unwind-info = "0.2.1"
 fallible-iterator = "0.3.0"
-arrayvec = "0.7.4"
+arrayvec = { version = "0.7.4", default-features = false }
+
+[features]
+default = ["std"]
+std = ["arrayvec/std", "thiserror", "gimli/std"]
 
 [dev-dependencies]
 object = "0.32"

--- a/src/aarch64/cache.rs
+++ b/src/aarch64/cache.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use super::unwind_rule::*;
 use crate::cache::*;

--- a/src/aarch64/mod.rs
+++ b/src/aarch64/mod.rs
@@ -2,7 +2,9 @@ mod arch;
 mod cache;
 mod dwarf;
 mod instruction_analysis;
+#[cfg(feature = "macho")]
 mod macho;
+#[cfg(feature = "pe")]
 mod pe;
 mod unwind_rule;
 mod unwinder;

--- a/src/aarch64/pe.rs
+++ b/src/aarch64/pe.rs
@@ -12,7 +12,7 @@ impl PeUnwinding for ArchAarch64 {
     ) -> Result<UnwindResult<Self::UnwindRule>, PeUnwinderError>
     where
         F: FnMut(u64) -> Result<u64, ()>,
-        D: std::ops::Deref<Target = [u8]>,
+        D: core::ops::Deref<Target = [u8]>,
     {
         Err(PeUnwinderError::Aarch64Unsupported)
     }

--- a/src/aarch64/unwinder.rs
+++ b/src/aarch64/unwinder.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use crate::{
     unwinder::UnwinderInternal, AllocationPolicy, Error, FrameAddress, MayAllocateDuringUnwind,

--- a/src/aarch64/unwindregs.rs
+++ b/src/aarch64/unwindregs.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::display_utils::HexNum;
 
@@ -137,7 +137,7 @@ impl UnwindRegsAarch64 {
 }
 
 impl Debug for UnwindRegsAarch64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("UnwindRegsAarch64")
             .field("lr", &HexNum(self.lr))
             .field("sp", &HexNum(self.sp))

--- a/src/arcdata.rs
+++ b/src/arcdata.rs
@@ -1,4 +1,5 @@
-use std::{fmt::Debug, ops::Deref, sync::Arc};
+use alloc::sync::Arc;
+use core::{fmt::Debug, ops::Deref};
 
 pub type ArcDataReader<D> = gimli::EndianReader<gimli::LittleEndian, ArcData<D>>;
 
@@ -19,7 +20,7 @@ impl<D: Deref<Target = [u8]>> Clone for ArcData<D> {
 }
 
 impl<D: Deref<Target = [u8]>> Debug for ArcData<D> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("ArcData").field(&self.0.as_ptr()).finish()
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,6 @@
-use std::ops::Deref;
+use core::ops::Deref;
+
+use alloc::boxed::Box;
 
 use crate::{rule_cache::RuleCache, unwind_rule::UnwindRule};
 

--- a/src/code_address.rs
+++ b/src/code_address.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU64;
+use core::num::NonZeroU64;
 
 /// An absolute code address for a stack frame. Can either be taken directly from the
 /// instruction pointer ("program counter"), or from a return address.

--- a/src/display_utils.rs
+++ b/src/display_utils.rs
@@ -1,9 +1,9 @@
-use std::fmt::{Binary, Debug, LowerHex};
+use core::fmt::{Binary, Debug, LowerHex};
 
 pub struct HexNum<N: LowerHex>(pub N);
 
 impl<N: LowerHex> Debug for HexNum<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         LowerHex::fmt(&self.0, f)
     }
 }
@@ -11,7 +11,7 @@ impl<N: LowerHex> Debug for HexNum<N> {
 pub struct BinNum<N: Binary>(pub N);
 
 impl<N: Binary> Debug for BinNum<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Binary::fmt(&self.0, f)
     }
 }

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -1,5 +1,6 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
+use alloc::vec::Vec;
 use gimli::{
     CfaRule, CieOrFde, DebugFrame, EhFrame, EhFrameHdr, Encoding, EndianSlice, Evaluation,
     EvaluationResult, EvaluationStorage, Expression, LittleEndian, Location, ParsedEhFrameHdr,
@@ -11,7 +12,9 @@ pub(crate) use gimli::BaseAddresses;
 
 use crate::{arch::Arch, unwind_result::UnwindResult, ModuleSectionInfo};
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DwarfUnwinderError {
     #[error("Could not get the FDE for the supplied offset: {0}")]
     FdeFromOffsetFailed(#[source] gimli::Error),
@@ -199,7 +202,9 @@ pub(crate) fn base_addresses_for_sections<D>(
         .set_got(start_addr(&[b"__got", b".got"]))
 }
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DwarfCfiIndexError {
     #[error("EhFrame processing failed: {0}")]
     Gimli(#[from] gimli::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,9 @@ use crate::macho::CompactUnwindInfoUnwinderError;
 use crate::pe::PeUnwinderError;
 
 /// The error type used in this crate.
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
     #[error("Could not read stack memory at 0x{0:x}")]
     CouldNotReadStack(u64),
@@ -21,7 +23,9 @@ pub enum Error {
     ReturnAddressIsNull,
 }
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnwinderError {
     #[error("Compact Unwind Info unwinding failed: {0}")]
     CompactUnwindInfo(#[source] CompactUnwindInfoUnwinderError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use crate::dwarf::DwarfUnwinderError;
+#[cfg(feature = "macho")]
 use crate::macho::CompactUnwindInfoUnwinderError;
+#[cfg(feature = "pe")]
 use crate::pe::PeUnwinderError;
 
 /// The error type used in this crate.
@@ -27,15 +29,18 @@ pub enum Error {
 #[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnwinderError {
+    #[cfg(feature = "macho")]
     #[error("Compact Unwind Info unwinding failed: {0}")]
     CompactUnwindInfo(#[source] CompactUnwindInfoUnwinderError),
 
     #[error("DWARF unwinding failed: {0}")]
     Dwarf(#[from] DwarfUnwinderError),
 
+    #[cfg(feature = "pe")]
     #[error("PE unwinding failed: {0}")]
     Pe(#[from] PeUnwinderError),
 
+    #[cfg(feature = "macho")]
     #[error("__unwind_info referred to DWARF FDE but we do not have __eh_frame data")]
     NoDwarfData,
 
@@ -49,6 +54,7 @@ pub enum UnwinderError {
     DwarfCfiIndexCouldNotFindAddress,
 }
 
+#[cfg(feature = "macho")]
 impl From<CompactUnwindInfoUnwinderError> for UnwinderError {
     fn from(e: CompactUnwindInfoUnwinderError) -> Self {
         match e {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! ## Example
 //!
 //! ```
-//! use std::ops::Range;
+//! use core::ops::Range;
 //! use framehop::aarch64::{CacheAarch64, UnwindRegsAarch64, UnwinderAarch64};
 //! use framehop::{ExplicitModuleSectionInfo, FrameAddress, Module};
 //!
@@ -110,6 +110,10 @@
 //!     ]
 //! );
 //! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod add_signed;
 mod arcdata;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,9 @@ mod display_utils;
 mod dwarf;
 mod error;
 mod instruction_analysis;
+#[cfg(feature = "macho")]
 mod macho;
+#[cfg(feature = "pe")]
 mod pe;
 mod rule_cache;
 mod unwind_result;

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -1,10 +1,12 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::dwarf::DwarfUnwinderError;
 use crate::{arch::Arch, unwind_rule::UnwindRule};
 use macho_unwind_info::UnwindInfo;
 
-#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompactUnwindInfoUnwinderError {
     #[error("Bad __unwind_info format: {0}")]
     BadFormat(#[from] macho_unwind_info::Error),

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -1,7 +1,11 @@
-use crate::{arch::Arch, unwind_result::UnwindResult};
-use std::ops::Range;
+use alloc::format;
 
-#[derive(thiserror::Error, Clone, Copy, Debug, PartialEq, Eq)]
+use crate::{arch::Arch, unwind_result::UnwindResult};
+use core::ops::Range;
+
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(not(feature = "std"), derive(thiserror_no_std::Error))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PeUnwinderError {
     #[error("failed to read unwind info memory at RVA {0:x}")]
     MissingUnwindInfoData(u32),
@@ -38,7 +42,7 @@ pub struct PeSections<'a, D> {
 
 impl<'a, D> PeSections<'a, D>
 where
-    D: std::ops::Deref<Target = [u8]>,
+    D: core::ops::Deref<Target = [u8]>,
 {
     pub fn unwind_info_memory_at_rva(&self, rva: u32) -> Result<&'a [u8], PeUnwinderError> {
         [&self.rdata, &self.xdata]
@@ -54,7 +58,7 @@ where
     }
 }
 
-fn memory_at_rva<D: std::ops::Deref<Target = [u8]>>(
+fn memory_at_rva<D: core::ops::Deref<Target = [u8]>>(
     DataAtRvaRange { data, rva_range }: &DataAtRvaRange<D>,
     address: u32,
 ) -> Option<&[u8]> {
@@ -76,5 +80,5 @@ pub trait PeUnwinding: Arch {
     ) -> Result<UnwindResult<Self::UnwindRule>, PeUnwinderError>
     where
         F: FnMut(u64) -> Result<u64, ()>,
-        D: std::ops::Deref<Target = [u8]>;
+        D: core::ops::Deref<Target = [u8]>;
 }

--- a/src/rule_cache.rs
+++ b/src/rule_cache.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::unwind_rule::UnwindRule;
 
 const CACHE_ENTRY_COUNT: usize = 509;
@@ -133,11 +135,11 @@ mod tests {
     #[test]
     fn test_cache_entry_size() {
         assert_eq!(
-            std::mem::size_of::<Option<CacheEntry<UnwindRuleX86_64>>>(),
+            core::mem::size_of::<Option<CacheEntry<UnwindRuleX86_64>>>(),
             16
         );
         assert_eq!(
-            std::mem::size_of::<Option<CacheEntry<UnwindRuleAarch64>>>(),
+            core::mem::size_of::<Option<CacheEntry<UnwindRuleAarch64>>>(),
             24 // <-- larger than we'd like
         );
     }

--- a/src/unwind_rule.rs
+++ b/src/unwind_rule.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 
-pub trait UnwindRule: Copy + std::fmt::Debug {
+pub trait UnwindRule: Copy + core::fmt::Debug {
     type UnwindRegs;
 
     fn exec<F>(

--- a/src/unwinder.rs
+++ b/src/unwinder.rs
@@ -1,3 +1,6 @@
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
 use fallible_iterator::FallibleIterator;
 use gimli::{EndianReader, LittleEndian};
 
@@ -16,12 +19,9 @@ use crate::unwind_result::UnwindResult;
 use crate::unwind_rule::UnwindRule;
 use crate::FrameAddress;
 
-use std::marker::PhantomData;
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::{
-    ops::{Deref, Range},
-    sync::Arc,
-};
+use core::marker::PhantomData;
+use core::ops::{Deref, Range};
+use core::sync::atomic::{AtomicU16, Ordering};
 
 /// Unwinder is the trait that each CPU architecture's concrete unwinder type implements.
 /// This trait's methods are what let you do the actual unwinding.
@@ -245,6 +245,7 @@ impl<
             .binary_search_by_key(&module.avma_range.start, |module| module.avma_range.start)
         {
             Ok(i) => {
+                #[cfg(feature = "std")]
                 eprintln!(
                     "Now we have two modules at the same start address 0x{:x}. This can't be good.",
                     module.avma_range.start
@@ -944,7 +945,7 @@ mod object {
 impl<D: Deref<Target = [u8]>> Module<D> {
     pub fn new(
         name: String,
-        avma_range: std::ops::Range<u64>,
+        avma_range: core::ops::Range<u64>,
         base_avma: u64,
         mut section_info: impl ModuleSectionInfo<D>,
     ) -> Self {

--- a/src/x86_64/cache.rs
+++ b/src/x86_64/cache.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use super::unwind_rule::*;
 use crate::cache::*;

--- a/src/x86_64/mod.rs
+++ b/src/x86_64/mod.rs
@@ -2,7 +2,9 @@ mod arch;
 mod cache;
 mod dwarf;
 mod instruction_analysis;
+#[cfg(feature = "macho")]
 mod macho;
+#[cfg(feature = "pe")]
 mod pe;
 mod register_ordering;
 mod unwind_rule;

--- a/src/x86_64/pe.rs
+++ b/src/x86_64/pe.rs
@@ -6,8 +6,9 @@ use super::{
 use crate::arch::Arch;
 use crate::pe::{PeSections, PeUnwinderError, PeUnwinding};
 use crate::unwind_result::UnwindResult;
-use std::ops::ControlFlow;
+use core::ops::ControlFlow;
 
+use alloc::vec::Vec;
 use pe_unwind_info::x86_64::{
     FunctionEpilogInstruction, FunctionTableEntries, Register, UnwindInfo, UnwindInfoTrailer,
     UnwindOperation, UnwindState,
@@ -102,7 +103,7 @@ impl PeUnwinding for ArchX86_64 {
     ) -> Result<UnwindResult<Self::UnwindRule>, PeUnwinderError>
     where
         F: FnMut(u64) -> Result<u64, ()>,
-        D: std::ops::Deref<Target = [u8]>,
+        D: core::ops::Deref<Target = [u8]>,
     {
         let entries = FunctionTableEntries::parse(sections.pdata);
         let Some(function) = entries.lookup(address) else {
@@ -168,7 +169,7 @@ impl PeUnwinding for ArchX86_64 {
         }
 
         // Get all chained UnwindInfo and resolve errors when collecting.
-        let chained_info = std::iter::successors(Some(Ok(unwind_info)), |info| {
+        let chained_info = core::iter::successors(Some(Ok(unwind_info)), |info| {
             let Ok(info) = info else {
                 return None;
             };

--- a/src/x86_64/unwinder.rs
+++ b/src/x86_64/unwinder.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use super::arch::ArchX86_64;
 use super::cache::CacheX86_64;

--- a/src/x86_64/unwindregs.rs
+++ b/src/x86_64/unwindregs.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use crate::display_utils::HexNum;
 
@@ -78,7 +78,7 @@ impl UnwindRegsX86_64 {
 }
 
 impl Debug for UnwindRegsX86_64 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("UnwindRegsX86_64")
             .field("ip", &HexNum(self.ip()))
             .field("rax", &HexNum(self.get(Reg::RAX)))


### PR DESCRIPTION
This incidentally fixes #7 .

This may be a big change, but the public API for this crate does not change after this PR, i.e. not breaking.

The goal of this is just to get this compiled for `no_std`, and removing support for `pe` and `macho` was needed as the `*-unwind-info` dependencies require `std` (didn't look too deep into them, so maybe we can change those as well).

The reason for `no_std` is that I wanted to integrate this into my kernel (https://github.com/Amjad50/Emerald).

I really like this project, and its really fast and more flexible to get stack traces.

Let me know what you think