### PR TITLE
Fix no_std compilation error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,3 +37,17 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
         run: cargo hack --feature-powerset check
+
+  no_std:
+    # Check for no_std compatibility
+    runs-on: ubuntu-latest
+    name: ${{ matrix.target }}
+    strategy:
+      matrix:
+        target: [thumbv7m-none-eabi, aarch64-unknown-none]
+    steps:
+      - uses: actions/checkout@v4
+      - name: rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
+      - name: cargo check
+        run: cargo check --target ${{ matrix.target }} --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/mstange/framehop/"
 exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 
 [dependencies]
-gimli = "0.29.0"
+gimli = { version = "0.29", default-features = false, features = ["read"] }
 object = { version = "0.35", optional = true }
 thiserror-no-std = "2.0.2"
 thiserror = { version = "1.0.0", optional = true }


### PR DESCRIPTION
This fixes a compilation error after 4bd7ecb, where `gimli` was added without restricting the features

Also added a CI test to make sure this doesn't happen by mistake