### PR TITLE
Reduce the features needed by the optional `object` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 
 [dependencies]
 gimli = { version = "0.29", default-features = false, features = ["read"] }
-object = { version = "0.35", optional = true }
+object = { version = "0.35", default-features = false, features = ["read_core"], optional = true }
 thiserror-no-std = "2.0.2"
 thiserror = { version = "1.0.0", optional = true }
 macho-unwind-info = { version = "0.4.0", optional = true }


### PR DESCRIPTION
We only need `read_core`. Users can add whichever features they want to support and it should "just work".