### PR TITLE
Remove the optional `object` feature and related ModuleSectionInfo implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 
 [dependencies]
 gimli = { version = "0.30", default-features = false, features = ["read"] }
-object = { version = "0.36", default-features = false, features = ["read_core"], optional = true }
 macho-unwind-info = { version = "0.4.0", optional = true }
 pe-unwind-info = { version = "0.2.1", optional = true }
 fallible-iterator = "0.3.0"

--- a/tests/integration_tests/common.rs
+++ b/tests/integration_tests/common.rs
@@ -54,16 +54,11 @@ where
         }
     }
 
-    #[cfg(not(feature = "object"))]
-    let section_info = Module(file);
-    #[cfg(feature = "object")]
-    let section_info = &file;
-
     let module = framehop::Module::new(
         objpath.to_string_lossy().to_string(),
         base_avma..(base_avma + buf.len() as u64),
         base_avma,
-        section_info,
+        Module(file),
     );
     unwinder.add_module(module);
 }


### PR DESCRIPTION
This functionality has been moved to the `framehop-object` crate.