### PR TITLE
Bump pe-unwind-info to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/.github", "/.vscode", "/tests", "/fixtures", "/big-fixtures"]
 [dependencies]
 gimli = { version = "0.31", default-features = false, features = ["read"] }
 macho-unwind-info = { version = "0.4.0", optional = true }
-pe-unwind-info = { version = "0.2.1", optional = true }
+pe-unwind-info = { version = "0.3.0", optional = true }
 fallible-iterator = "0.3.0"
 arrayvec = { version = "0.7.4", default-features = false }
 cfg-if = "1.0.0"

--- a/src/unwinder.rs
+++ b/src/unwinder.rs
@@ -105,7 +105,7 @@ pub trait Unwinder: Clone {
 ///  - `'u`: The lifetime of the [`Unwinder`].
 ///  - `'c`: The lifetime of the unwinder cache.
 ///  - `'r`: The lifetime of the exclusive access to the `read_stack` callback.
-pub struct UnwindIterator<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>> {
+pub struct UnwindIterator<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>> {
     unwinder: &'u U,
     state: UnwindIteratorState,
     regs: U::UnwindRegs,
@@ -119,7 +119,7 @@ enum UnwindIteratorState {
     Done,
 }
 
-impl<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>>
+impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>>
     UnwindIterator<'u, 'c, 'r, U, F>
 {
     /// Create a new iterator. You'd usually use [`Unwinder::iter_frames`] instead.
@@ -140,7 +140,7 @@ impl<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>>
     }
 }
 
-impl<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>>
+impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>>
     UnwindIterator<'u, 'c, 'r, U, F>
 {
     /// Yield the next frame in the stack.
@@ -179,7 +179,7 @@ impl<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>>
     }
 }
 
-impl<'u, 'c, 'r, U: Unwinder + ?Sized, F: FnMut(u64) -> Result<u64, ()>> FallibleIterator
+impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>> FallibleIterator
     for UnwindIterator<'u, 'c, 'r, U, F>
 {
     type Item = FrameAddress;

--- a/src/unwinder.rs
+++ b/src/unwinder.rs
@@ -119,9 +119,7 @@ enum UnwindIteratorState {
     Done,
 }
 
-impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>>
-    UnwindIterator<'u, 'c, 'r, U, F>
-{
+impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>> UnwindIterator<'u, 'c, 'r, U, F> {
     /// Create a new iterator. You'd usually use [`Unwinder::iter_frames`] instead.
     pub fn new(
         unwinder: &'u U,
@@ -140,9 +138,7 @@ impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>>
     }
 }
 
-impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>>
-    UnwindIterator<'u, 'c, 'r, U, F>
-{
+impl<'u, 'c, 'r, U: Unwinder, F: FnMut(u64) -> Result<u64, ()>> UnwindIterator<'u, 'c, 'r, U, F> {
     /// Yield the next frame in the stack.
     ///
     /// The first frame is `Ok(Some(FrameAddress::InstructionPointer(...)))`.


### PR DESCRIPTION
Per [semver rules](https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility), having `pe-unwind-info` 0.2.1 in `Cargo.toml` means that 0.2.3 will be used instead unless `--locked` is passed on the command-line. [That version is broken](https://github.com/mozilla/pe-unwind-info/blob/0.2.3/src/x86_64.rs#L9-L10), and the next one is 0.3.0, which is not selected by semver rules. However, [it seems fine to use for framehope](https://github.com/mozilla/pe-unwind-info/compare/0.2.3...0.3.0).