### PR TITLE
Support memory-backed DWARF CFA expressions

### DIFF
--- a/src/aarch64/dwarf.rs
+++ b/src/aarch64/dwarf.rs
@@ -50,7 +50,7 @@ impl DwarfUnwinding for ArchAarch64 {
             }
         }
 
-        let cfa = eval_cfa_rule::<R, _, ES>(section, cfa_rule, encoding, regs)
+        let cfa = eval_cfa_rule::<R, F, _, ES>(section, cfa_rule, encoding, regs, read_stack)
             .ok_or(DwarfUnwinderError::CouldNotRecoverCfa)?;
 
         let lr = regs.lr();

--- a/src/dwarf.rs
+++ b/src/dwarf.rs
@@ -386,12 +386,19 @@ pub trait DwarfUnwindRegs {
     fn get(&self, register: Register) -> Option<u64>;
 }
 
-pub fn eval_cfa_rule<R: Reader, UR: DwarfUnwindRegs, S: EvaluationStorage<R>>(
+pub fn eval_cfa_rule<R, F, UR, S>(
     section: &impl UnwindSection<R>,
     rule: &CfaRule<R::Offset>,
     encoding: Encoding,
     regs: &UR,
-) -> Option<u64> {
+    read_stack: &mut F,
+) -> Option<u64>
+where
+    R: Reader,
+    F: FnMut(u64) -> Result<u64, ()>,
+    UR: DwarfUnwindRegs,
+    S: EvaluationStorage<R>,
+{
     match rule {
         CfaRule::RegisterAndOffset { register, offset } => {
             let val = regs.get(*register)?;
@@ -399,16 +406,23 @@ pub fn eval_cfa_rule<R: Reader, UR: DwarfUnwindRegs, S: EvaluationStorage<R>>(
         }
         CfaRule::Expression(expr) => {
             let expr = expr.get(section).ok()?;
-            eval_expr::<R, UR, S>(expr, encoding, regs)
+            eval_expr::<R, F, UR, S>(expr, encoding, regs, read_stack)
         }
     }
 }
 
-fn eval_expr<R: Reader, UR: DwarfUnwindRegs, S: EvaluationStorage<R>>(
+fn eval_expr<R, F, UR, S>(
     expr: Expression<R>,
     encoding: Encoding,
     regs: &UR,
-) -> Option<u64> {
+    read_stack: &mut F,
+) -> Option<u64>
+where
+    R: Reader,
+    F: FnMut(u64) -> Result<u64, ()>,
+    UR: DwarfUnwindRegs,
+    S: EvaluationStorage<R>,
+{
     let mut eval = Evaluation::<R, S>::new_in(expr.0, encoding);
     let mut result = eval.evaluate().ok()?;
     loop {
@@ -416,7 +430,19 @@ fn eval_expr<R: Reader, UR: DwarfUnwindRegs, S: EvaluationStorage<R>>(
             EvaluationResult::Complete => break,
             EvaluationResult::RequiresRegister { register, .. } => {
                 let value = regs.get(register)?;
-                result = eval.resume_with_register(Value::Generic(value as _)).ok()?;
+                result = eval.resume_with_register(Value::Generic(value)).ok()?;
+            }
+            EvaluationResult::RequiresMemory {
+                address,
+                size,
+                space,
+                ..
+            } => {
+                if space.is_some() || size != encoding.address_size {
+                    return None;
+                }
+                let value = read_stack(address).ok()?;
+                result = eval.resume_with_memory(Value::Generic(value)).ok()?;
             }
             _ => return None,
         }
@@ -459,12 +485,12 @@ where
         RegisterRule::Register(register) => regs.get(register),
         RegisterRule::Expression(expr) => {
             let expr = expr.get(section).ok()?;
-            let val = eval_expr::<R, UR, S>(expr, encoding, regs)?;
+            let val = eval_expr::<R, F, UR, S>(expr, encoding, regs, read_stack)?;
             read_stack(val).ok()
         }
         RegisterRule::ValExpression(expr) => {
             let expr = expr.get(section).ok()?;
-            eval_expr::<R, UR, S>(expr, encoding, regs)
+            eval_expr::<R, F, UR, S>(expr, encoding, regs, read_stack)
         }
         RegisterRule::Architectural => {
             // Unimplemented
@@ -472,5 +498,134 @@ where
             None
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gimli::{AArch64, DebugFrame, Format, StoreOnHeap, UnwindExpression, X86_64};
+
+    use crate::{
+        aarch64::UnwindRegsAarch64,
+        x86_64::{Reg, UnwindRegsX86_64},
+    };
+
+    use super::*;
+
+    fn encoding() -> Encoding {
+        Encoding {
+            address_size: 8,
+            format: Format::Dwarf32,
+            version: 4,
+        }
+    }
+
+    #[test]
+    fn eval_cfa_expression_can_read_memory_with_x86_64_regs() {
+        // DW_OP_breg6(RBP) -40; DW_OP_deref
+        let expression = [0x76, 0x58, 0x06];
+        let mut section = DebugFrame::from(EndianSlice::new(&expression, LittleEndian));
+        section.set_address_size(8);
+        let rule = CfaRule::Expression(UnwindExpression {
+            offset: 0,
+            length: expression.len(),
+        });
+        let regs = UnwindRegsX86_64::new(0, 0, 0x1000);
+
+        let mut unreadable_stack = |_| Err(());
+        assert_eq!(
+            eval_cfa_rule::<_, _, _, StoreOnHeap>(
+                &section,
+                &rule,
+                encoding(),
+                &regs,
+                &mut unreadable_stack,
+            ),
+            None
+        );
+
+        let mut read_stack = |address| {
+            assert_eq!(address, 0xfd8);
+            Ok(0x2000)
+        };
+
+        assert_eq!(
+            eval_cfa_rule::<_, _, _, StoreOnHeap>(
+                &section,
+                &rule,
+                encoding(),
+                &regs,
+                &mut read_stack,
+            ),
+            Some(0x2000)
+        );
+    }
+
+    #[test]
+    fn eval_cfa_expression_can_read_memory_with_aarch64_regs() {
+        // DW_OP_breg29(X29/FP) -16; DW_OP_deref
+        let expression = [0x8d, 0x70, 0x06];
+        let mut section = DebugFrame::from(EndianSlice::new(&expression, LittleEndian));
+        section.set_address_size(8);
+        let rule = CfaRule::Expression(UnwindExpression {
+            offset: 0,
+            length: expression.len(),
+        });
+        let regs = UnwindRegsAarch64::new(0, 0, 0x3000);
+        assert_eq!(DwarfUnwindRegs::get(&regs, AArch64::X29), Some(0x3000));
+
+        let mut read_stack = |address| {
+            assert_eq!(address, 0x2ff0);
+            Ok(0x4000)
+        };
+
+        assert_eq!(
+            eval_cfa_rule::<_, _, _, StoreOnHeap>(
+                &section,
+                &rule,
+                encoding(),
+                &regs,
+                &mut read_stack,
+            ),
+            Some(0x4000)
+        );
+    }
+
+    #[test]
+    fn eval_cfa_expression_rejects_partial_memory_reads() {
+        // DW_OP_breg6(RBP) -40; DW_OP_deref_size 4
+        let expression = [0x76, 0x58, 0x94, 0x04];
+        let mut section = DebugFrame::from(EndianSlice::new(&expression, LittleEndian));
+        section.set_address_size(8);
+        let rule = CfaRule::Expression(UnwindExpression {
+            offset: 0,
+            length: expression.len(),
+        });
+        let regs = UnwindRegsX86_64::new(0, 0, 0x1000);
+
+        let mut read_stack =
+            |_: u64| -> Result<u64, ()> { panic!("partial memory reads are unsupported") };
+
+        assert_eq!(
+            eval_cfa_rule::<_, _, _, StoreOnHeap>(
+                &section,
+                &rule,
+                encoding(),
+                &regs,
+                &mut read_stack,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn x86_64_dwarf_regs_expose_provided_general_purpose_registers() {
+        let mut regs = UnwindRegsX86_64::new(0, 0, 0);
+        assert_eq!(DwarfUnwindRegs::get(&regs, X86_64::R10), None);
+
+        regs.set(Reg::R10, 0x1234);
+
+        assert_eq!(DwarfUnwindRegs::get(&regs, X86_64::R10), Some(0x1234));
+        assert_eq!(DwarfUnwindRegs::get(&regs, X86_64::R11), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! Framehop achieves high speed in the following ways:
 //!
-//!  1. It only recovers registers which are needed for computing return addresses. On x86_64 that's `rip`, `rsp` and `rbp`, and on aarch64 that's `lr`, `sp` and `fp`. All other registers are not needed - in theory they could be used as inputs to DWARF CFI expressions, but in practice they are not.
+//!  1. It only recovers registers which are needed for computing return addresses. On x86_64 that's usually `rip`, `rsp` and `rbp`, and on aarch64 that's `lr`, `sp` and `fp`. x86_64 callers can also provide the other general-purpose registers for uncommon DWARF CFI expressions.
 //!  2. It uses zero-copy parsing wherever possible. For example, the bytes in `__unwind_info` are only accessed during unwinding, and the binary search happens right inside the original `__unwind_info` memory. For DWARF unwinding, framehop uses the excellent [`gimli` crate](https://github.com/gimli-rs/gimli/), which was written with performance in mind.
 //!  3. It uses binary search to find the correct unwind rule in all supported unwind information formats. For formats without an built-in index, it creates an index when the module is added.
 //!  4. It caches unwind rules based on address. In practice, the 509-slot cache achieves a hit rate of around 80% on complicated code like Firefox (with the cache being shared across all Firefox processes). When profiling simpler applications, the hit rate is likely much higher.

--- a/src/x86_64/dwarf.rs
+++ b/src/x86_64/dwarf.rs
@@ -3,7 +3,11 @@ use gimli::{
     UnwindContextStorage, UnwindSection, UnwindTableRow, X86_64,
 };
 
-use super::{arch::ArchX86_64, unwind_rule::UnwindRuleX86_64, unwindregs::UnwindRegsX86_64};
+use super::{
+    arch::ArchX86_64,
+    unwind_rule::UnwindRuleX86_64,
+    unwindregs::{Reg, UnwindRegsX86_64},
+};
 use crate::dwarf::{
     eval_cfa_rule, eval_register_rule, ConversionError, DwarfUnwindRegs, DwarfUnwinderError,
     DwarfUnwinding,
@@ -14,8 +18,23 @@ impl DwarfUnwindRegs for UnwindRegsX86_64 {
     fn get(&self, register: Register) -> Option<u64> {
         match register {
             X86_64::RA => Some(self.ip()),
+            X86_64::RAX => self.get_if_set(Reg::RAX),
+            X86_64::RDX => self.get_if_set(Reg::RDX),
+            X86_64::RCX => self.get_if_set(Reg::RCX),
+            X86_64::RBX => self.get_if_set(Reg::RBX),
+            X86_64::RSI => self.get_if_set(Reg::RSI),
+            X86_64::RDI => self.get_if_set(Reg::RDI),
+            // RSP/RBP are always populated by `UnwindRegsX86_64::new`.
             X86_64::RSP => Some(self.sp()),
             X86_64::RBP => Some(self.bp()),
+            X86_64::R8 => self.get_if_set(Reg::R8),
+            X86_64::R9 => self.get_if_set(Reg::R9),
+            X86_64::R10 => self.get_if_set(Reg::R10),
+            X86_64::R11 => self.get_if_set(Reg::R11),
+            X86_64::R12 => self.get_if_set(Reg::R12),
+            X86_64::R13 => self.get_if_set(Reg::R13),
+            X86_64::R14 => self.get_if_set(Reg::R14),
+            X86_64::R15 => self.get_if_set(Reg::R15),
             _ => None,
         }
     }
@@ -48,7 +67,7 @@ impl DwarfUnwinding for ArchX86_64 {
             }
         }
 
-        let cfa = eval_cfa_rule::<R, _, ES>(section, cfa_rule, encoding, regs)
+        let cfa = eval_cfa_rule::<R, F, _, ES>(section, cfa_rule, encoding, regs, read_stack)
             .ok_or(DwarfUnwinderError::CouldNotRecoverCfa)?;
 
         let ip = regs.ip();
@@ -76,6 +95,7 @@ impl DwarfUnwinding for ArchX86_64 {
             return Err(DwarfUnwinderError::StackPointerMovedBackwards);
         }
 
+        regs.clear_unrestored_caller_registers();
         regs.set_ip(return_address);
         regs.set_bp(new_bp);
         regs.set_sp(cfa);

--- a/src/x86_64/unwind_rule.rs
+++ b/src/x86_64/unwind_rule.rs
@@ -109,6 +109,7 @@ impl UnwindRule for UnwindRuleX86_64 {
         F: FnMut(u64) -> Result<u64, ()>,
     {
         let sp = regs.sp();
+        let mut restored_regs = ArrayVec::<(Reg, u64), 8>::new();
         let (new_sp, new_bp) = match self {
             UnwindRuleX86_64::EndOfStack => return Ok(None),
             UnwindRuleX86_64::JustReturn => {
@@ -231,9 +232,13 @@ impl UnwindRule for UnwindRuleX86_64 {
                 for reg in register_ordering::decode(register_count, encoded_registers_to_pop) {
                     let value = read_stack(sp).map_err(|_| Error::CouldNotReadStack(sp))?;
                     sp = sp.checked_add(8).ok_or(Error::IntegerOverflow)?;
-                    regs.set(reg, value);
+                    restored_regs.push((reg, value));
                 }
-                (sp.checked_add(8).ok_or(Error::IntegerOverflow)?, regs.bp())
+                let new_bp = restored_regs
+                    .iter()
+                    .find_map(|(reg, value)| (*reg == Reg::RBP).then_some(*value))
+                    .unwrap_or_else(|| regs.bp());
+                (sp.checked_add(8).ok_or(Error::IntegerOverflow)?, new_bp)
             }
         };
         let return_address =
@@ -243,6 +248,10 @@ impl UnwindRule for UnwindRuleX86_64 {
         }
         if new_sp == sp && return_address == regs.ip() {
             return Err(Error::DidNotAdvance);
+        }
+        regs.clear_unrestored_caller_registers();
+        for (reg, value) in restored_regs {
+            regs.set(reg, value);
         }
         regs.set_ip(return_address);
         regs.set_sp(new_sp);
@@ -305,5 +314,45 @@ mod test {
         assert_eq!(res, Err(Error::IntegerOverflow));
         let res = UnwindRuleX86_64::UseFramePointer.exec(true, &mut regs, &mut read_stack);
         assert_eq!(res, Err(Error::IntegerOverflow));
+    }
+
+    #[test]
+    fn test_unwind_clears_unrestored_general_purpose_registers() {
+        let stack = [0x100200, 0x100100];
+        let mut read_stack = |addr| Ok(stack[(addr / 8) as usize]);
+        let mut regs = UnwindRegsX86_64::new(0x100300, 0, 0x20);
+        regs.set(Reg::RAX, 0xaa);
+        regs.set(Reg::RBX, 0xbb);
+
+        let res =
+            UnwindRuleX86_64::OffsetSp { sp_offset_by_8: 1 }.exec(true, &mut regs, &mut read_stack);
+
+        assert_eq!(res, Ok(Some(0x100200)));
+        assert_eq!(regs.get_if_set(Reg::RAX), None);
+        assert_eq!(regs.get_if_set(Reg::RBX), None);
+        assert_eq!(regs.get_if_set(Reg::RSP), Some(8));
+        assert_eq!(regs.get_if_set(Reg::RBP), Some(0x20));
+    }
+
+    #[test]
+    fn test_unwind_keeps_restored_general_purpose_registers() {
+        let stack = [0xbeef, 0x100200];
+        let mut read_stack = |addr| Ok(stack[(addr / 8) as usize]);
+        let mut regs = UnwindRegsX86_64::new(0x100300, 0, 0x20);
+        regs.set(Reg::RAX, 0xaa);
+        regs.set(Reg::RBX, 0xbb);
+
+        let res = UnwindRuleX86_64::OffsetSpAndPopRegisters {
+            sp_offset_by_8: 0,
+            register_count: 1,
+            encoded_registers_to_pop: 0,
+        }
+        .exec(true, &mut regs, &mut read_stack);
+
+        assert_eq!(res, Ok(Some(0x100200)));
+        assert_eq!(regs.get_if_set(Reg::RAX), None);
+        assert_eq!(regs.get_if_set(Reg::RBX), Some(0xbeef));
+        assert_eq!(regs.get_if_set(Reg::RSP), Some(16));
+        assert_eq!(regs.get_if_set(Reg::RBP), Some(0x20));
     }
 }

--- a/src/x86_64/unwindregs.rs
+++ b/src/x86_64/unwindregs.rs
@@ -6,6 +6,7 @@ use crate::display_utils::HexNum;
 pub struct UnwindRegsX86_64 {
     ip: u64,
     regs: [u64; 16],
+    valid_regs: u16,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -34,6 +35,7 @@ impl UnwindRegsX86_64 {
         let mut r = Self {
             ip,
             regs: Default::default(),
+            valid_regs: 0,
         };
         r.set_sp(sp);
         r.set_bp(bp);
@@ -41,12 +43,30 @@ impl UnwindRegsX86_64 {
     }
 
     #[inline(always)]
+    fn valid_reg_bit(reg: Reg) -> u16 {
+        1u16 << (reg as u8)
+    }
+
+    #[inline(always)]
     pub fn get(&self, reg: Reg) -> u64 {
         self.regs[reg as usize]
     }
     #[inline(always)]
+    pub fn get_if_set(&self, reg: Reg) -> Option<u64> {
+        if self.valid_regs & Self::valid_reg_bit(reg) != 0 {
+            Some(self.get(reg))
+        } else {
+            None
+        }
+    }
+    #[inline(always)]
     pub fn set(&mut self, reg: Reg, value: u64) {
         self.regs[reg as usize] = value;
+        self.valid_regs |= Self::valid_reg_bit(reg);
+    }
+    #[inline(always)]
+    pub(crate) fn clear_unrestored_caller_registers(&mut self) {
+        self.valid_regs &= Self::valid_reg_bit(Reg::RBP) | Self::valid_reg_bit(Reg::RSP);
     }
 
     #[inline(always)]
@@ -77,26 +97,46 @@ impl UnwindRegsX86_64 {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn clear_unrestored_caller_registers_keeps_frame_registers() {
+        let mut regs = UnwindRegsX86_64::new(0x100, 0x200, 0x300);
+        regs.set(Reg::RAX, 0x400);
+        regs.set(Reg::RBX, 0x500);
+
+        regs.clear_unrestored_caller_registers();
+
+        assert_eq!(regs.ip(), 0x100);
+        assert_eq!(regs.get_if_set(Reg::RSP), Some(0x200));
+        assert_eq!(regs.get_if_set(Reg::RBP), Some(0x300));
+        assert_eq!(regs.get_if_set(Reg::RAX), None);
+        assert_eq!(regs.get_if_set(Reg::RBX), None);
+    }
+}
+
 impl Debug for UnwindRegsX86_64 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("UnwindRegsX86_64")
             .field("ip", &HexNum(self.ip()))
-            .field("rax", &HexNum(self.get(Reg::RAX)))
-            .field("rdx", &HexNum(self.get(Reg::RDX)))
-            .field("rcx", &HexNum(self.get(Reg::RCX)))
-            .field("rbx", &HexNum(self.get(Reg::RBX)))
-            .field("rsi", &HexNum(self.get(Reg::RSI)))
-            .field("rdi", &HexNum(self.get(Reg::RDI)))
-            .field("rbp", &HexNum(self.get(Reg::RBP)))
-            .field("rsp", &HexNum(self.get(Reg::RSP)))
-            .field("r8", &HexNum(self.get(Reg::R8)))
-            .field("r9", &HexNum(self.get(Reg::R9)))
-            .field("r10", &HexNum(self.get(Reg::R10)))
-            .field("r11", &HexNum(self.get(Reg::R11)))
-            .field("r12", &HexNum(self.get(Reg::R12)))
-            .field("r13", &HexNum(self.get(Reg::R13)))
-            .field("r14", &HexNum(self.get(Reg::R14)))
-            .field("r15", &HexNum(self.get(Reg::R15)))
+            .field("rax", &self.get_if_set(Reg::RAX).map(HexNum))
+            .field("rdx", &self.get_if_set(Reg::RDX).map(HexNum))
+            .field("rcx", &self.get_if_set(Reg::RCX).map(HexNum))
+            .field("rbx", &self.get_if_set(Reg::RBX).map(HexNum))
+            .field("rsi", &self.get_if_set(Reg::RSI).map(HexNum))
+            .field("rdi", &self.get_if_set(Reg::RDI).map(HexNum))
+            .field("rbp", &self.get_if_set(Reg::RBP).map(HexNum))
+            .field("rsp", &self.get_if_set(Reg::RSP).map(HexNum))
+            .field("r8", &self.get_if_set(Reg::R8).map(HexNum))
+            .field("r9", &self.get_if_set(Reg::R9).map(HexNum))
+            .field("r10", &self.get_if_set(Reg::R10).map(HexNum))
+            .field("r11", &self.get_if_set(Reg::R11).map(HexNum))
+            .field("r12", &self.get_if_set(Reg::R12).map(HexNum))
+            .field("r13", &self.get_if_set(Reg::R13).map(HexNum))
+            .field("r14", &self.get_if_set(Reg::R14).map(HexNum))
+            .field("r15", &self.get_if_set(Reg::R15).map(HexNum))
             .finish()
     }
 }

--- a/tests/integration_tests/linux.rs
+++ b/tests/integration_tests/linux.rs
@@ -145,6 +145,98 @@ fn test_pthread_cfa_expr() {
 }
 
 #[test]
+fn test_signal_trampoline_cfa_expr_with_memory_deref() {
+    let mut cache = CacheX86_64::<_>::new();
+    let mut unwinder = UnwinderX86_64::new();
+    common::add_object(
+        &mut unwinder,
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/linux/x86_64/nofp/libc.so.6"),
+        0x0,
+    );
+
+    // From the __restore_rt FDE in fixtures/linux/x86_64/nofp/libc.so.6:
+    //
+    // __restore_rt:
+    // 46520  mov  rax, 0xf
+    // 46527  syscall
+    //
+    // with DWARF CFI:
+    //
+    // 0x4651f...0x46529:
+    //   CFA=DW_OP_breg7(RSP) +160, DW_OP_deref
+    //   RBP=DW_OP_breg7(RSP) +120
+    //   RIP=DW_OP_breg7(RSP) +168
+    // With RSP=0x80, the CFA expression reads [RSP+160] = [0x120].
+    // The RBP and RIP expressions read [RSP+120] and [RSP+168].
+    let mut stack = vec![0u64; 0x200 / 8];
+    stack[0x0f8 / 8] = 0x4567;
+    stack[0x120 / 8] = 0x188;
+    stack[0x128 / 8] = 0x123456;
+    let mut read_stack = |addr| stack.get((addr / 8) as usize).cloned().ok_or(());
+
+    let mut regs = UnwindRegsX86_64::new(0x46527, 0x80, 0x9999);
+    let res = unwinder.unwind_frame(
+        FrameAddress::from_instruction_pointer(0x46527),
+        &mut regs,
+        &mut cache,
+        &mut read_stack,
+    );
+    assert_eq!(res, Ok(Some(0x123456)));
+    assert_eq!(regs.sp(), 0x188);
+    assert_eq!(regs.bp(), 0x4567);
+}
+
+#[test]
+fn test_cfa_expr_with_general_purpose_register() {
+    let mut cache = CacheX86_64::<_>::new();
+    let mut unwinder = UnwinderX86_64::new();
+    common::add_object(
+        &mut unwinder,
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/linux/x86_64/nofp/rustup"),
+        0x0,
+    );
+
+    // From the GFp_bn_mul_mont FDE in fixtures/linux/x86_64/nofp/rustup:
+    //
+    // GFp_bn_mul_mont:
+    // 5f25c0  push  rbx
+    // 5f25c1  push  rbp
+    // 5f25c2  push  r12
+    // 5f25c4  push  r13
+    // 5f25c6  push  r14
+    // 5f25c8  push  r15
+    // ...
+    // 5f2616  mov   r12, rdx
+    //
+    // with DWARF CFI:
+    //
+    // 0x5f2616:
+    //   CFA=DW_OP_breg7(RSP) +8, DW_OP_breg9(R9) +0, DW_OP_lit8,
+    //       DW_OP_mul, DW_OP_plus, DW_OP_deref, DW_OP_plus_uconst +8
+    //   RBP=[CFA-24]
+    //   RIP=[CFA-8]
+    // With RSP=0x80 and R9=4, the CFA expression reads
+    // [RSP + 8 + R9 * 8] = [0xa8], then adds 8.
+    let mut stack = vec![0u64; 0x200 / 8];
+    stack[0x0a8 / 8] = 0x180;
+    stack[0x170 / 8] = 0x4567;
+    stack[0x180 / 8] = 0x123456;
+    let mut read_stack = |addr| stack.get((addr / 8) as usize).cloned().ok_or(());
+
+    let mut regs = UnwindRegsX86_64::new(0x5f2616, 0x80, 0x9999);
+    regs.set(Reg::R9, 4);
+    let res = unwinder.unwind_frame(
+        FrameAddress::from_instruction_pointer(0x5f2616),
+        &mut regs,
+        &mut cache,
+        &mut read_stack,
+    );
+    assert_eq!(res, Ok(Some(0x123456)));
+    assert_eq!(regs.sp(), 0x188);
+    assert_eq!(regs.bp(), 0x4567);
+}
+
+#[test]
 fn test_no_eh_frame_hdr() {
     let mut cache = CacheAarch64::<_>::new();
     let mut unwinder = UnwinderAarch64::new();


### PR DESCRIPTION
Some libraries describe the CFA with a DWARF expression instead of the usual register-plus-offset setup. In the case we hit, the unwinder needs to read the stack at RBP - 40 to recover the CFA.

This lets the shared DWARF expression evaluator use the existing read_stack callback for pointer-sized memory reads. The generic x86_64 and aarch64 CFA paths now go through that evaluator too.

For x86_64, callers can also provide extra registers for less common bregN expressions, and missing registers now fail cleanly instead of being treated as zero. aarch64 still only uses the registers its unwind state currently stores.